### PR TITLE
Ensure MailMessage disposal and handle send errors

### DIFF
--- a/Presensia/Services/EmailService.cs
+++ b/Presensia/Services/EmailService.cs
@@ -34,7 +34,7 @@ namespace Presensia.Services
                 Credentials = new NetworkCredential(_opts.User, _opts.Password)
             };
 
-            var msg = new MailMessage
+            using var msg = new MailMessage
             {
                 From = new MailAddress(_opts.From),
                 Subject = subject,
@@ -45,7 +45,15 @@ namespace Presensia.Services
             if (!string.IsNullOrWhiteSpace(replyTo))
                 msg.ReplyToList.Add(new MailAddress(replyTo!));
 
-            await client.SendMailAsync(msg);
+            try
+            {
+                await client.SendMailAsync(msg);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error sending email: {ex}");
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Dispose `MailMessage` via using to release resources
- Wrap `SendMailAsync` in try/catch and log errors before rethrowing

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c7ea538e288333b78e7131e7dd4c41